### PR TITLE
Remove not deprecated string file as it is no longer required

### DIFF
--- a/lang/en/deprecated.txt
+++ b/lang/en/deprecated.txt
@@ -1,1 +1,0 @@
- assigngroup_confirm.mod_groupselect


### PR DESCRIPTION
There is a deprecated string file in lang/en that is no longer required as the string has been removed from the lang pack.
Having the string still flagged as deprecated event hough it has been removed causes a core unit test fail.