### PR TITLE
Add more export options using tablelib

### DIFF
--- a/lang/es/groupselect.php
+++ b/lang/es/groupselect.php
@@ -1,0 +1,121 @@
+<?php
+
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Strings for component 'groupselect', language 'es', branch 'MOODLE_35_STABLE'
+ *
+ * @package   groupselect
+ * @copyright 1999 onwards Martin Dougiamas  {@link http://moodle.com}
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+$string['action'] = 'Acción';
+$string['assignedteacher'] = 'Asignado profesor sin permiso de edición';
+$string['assigngroup'] = 'Asignar profesor sin permiso de edición a grupos';
+$string['assigngroup_help'] = 'Si se establece, habilita un botón para asignar profesores sin permiso de edición a los grupos (si el curso tiene profesores sin permiso de edición). Los profesores sin permiso de edición asignados no son miembros del grupo, pero aparecen en el archivo de exportación y en la vista principal (si está configurada). Puede ser útil si el curso utiliza asistentes para manejar grupos.';
+$string['cannotselectclosed'] = 'No podrá ser miembro de un grupo nunca más.';
+$string['cannotselectmaxed'] = 'No puede unirse al grupo {$a} - número máximo de miembros alcanzado.';
+$string['cannotselectnocap'] = 'No está autorizado para seleccionar un grupo.';
+$string['cannotselectnoenrol'] = 'Es necesario estar matriculado en el curso para poder convertirse en un miembro del grupo.';
+$string['cannotunselectclosed'] = 'No podrá abandonar el grupo nunca más';
+$string['creategroup'] = 'Crear un nuevo grupo';
+$string['deleteemptygroups'] = 'Eliminar grupo cuando el último estudiante lo abandone';
+$string['deleteemptygroups_help'] = 'Si se establece, elimina automáticamente el grupo cuando el último estudiante lo abandone';
+$string['description'] = 'Descripción del grupo';
+$string['edittooltip'] = 'Haga clic para editar';
+$string['eventexportlinkcreated'] = 'Enlace de exportación creado';
+$string['eventgroupteacheradded'] = 'Supervisor añadido';
+$string['export'] = 'Crear un enlace para descargar el archivo de datos del grupo (CSV)';
+$string['export_download'] = 'Descargar archivo CSV';
+/* New export strings */
+$string['export_formatchoose'] = 'Escoja el formato para la exportación';
+$string['export_newcsv'] = 'Listado de usuarios y pertenencia a grupos (CSV)';
+$string['export_newexcel'] = 'Listado de usuarios y pertenencia a grupos (Excel)';
+$string['export_newods'] = 'Listado de usuarios y pertenencia a grupos (ODS)';
+$string['export_classiccsv'] = 'Listado mostrado abajo (CSV)';
+$string['export_classicexcel'] = 'Listado mostrado abajo (Excel)';
+$string['export_classicods'] = 'Listado mostrado abajo (ODS)';
+/**/
+$string['fromallgroups'] = 'Todos los grupos';
+$string['globalpassword_help'] = 'Establecer una contraseña global para apuntarse a un grupo. Sobreescribe la contraseña de los estudiantes.';
+$string['groupid'] = 'ID Grupo';
+$string['groupselect:addinstance'] = 'Añadir un nuevo grupo auto-seleccionado';
+$string['groupselect:assign'] = 'Permitir asignar profesores a los grupos';
+$string['groupselect:create'] = 'Permitir creación de grupos';
+$string['groupselect:export'] = 'Permitir la exportación de miembros de grupo';
+$string['groupselect:select'] = 'Permitir apuntarse a un grupo';
+$string['groupselect:unselect'] = 'Permitir abandonar un grupo';
+$string['hidefullgroups'] = 'Ocultar grupos completos de la vista principal';
+$string['hidefullgroups_help'] = 'Si se establece, se ocultan todos los grupos que han alcanzado el número máximo de miembros, de la vista principal (excluyendo el grupo al que pertenece el usuario). Puede ser útil si la actividad tiene muchos grupos.';
+$string['incorrectpassword'] = 'Contraseña incorrecta';
+$string['managegroups'] = 'Administrar grupos';
+$string['maxcharlenreached'] = 'Número máximo de carácteres alcanzado';
+$string['maxgroupmembership'] = 'Número máximo de grupos que el estudiante puede seleccionar';
+$string['maxgroupmembership_error_low'] = '¡Error: al menos un grupo tiene que ser seleccionable!';
+$string['maxlimitreached'] = 'Número máximo alcanzado';
+$string['maxmembers'] = 'Número máximo de miembros por grupo';
+$string['maxmembers_error_low'] = '¡Error: usa 0 para indicar tamaño ilimitado!';
+$string['maxmembers_error_smaller_minmembers'] = '¡Error: necesita ser mayor que el mínimo de participantes por grupo!';
+$string['maxmembers_help'] = 'Número máximo de miembros por grupo, 0 para ilimitados';
+$string['maxmembers_icon'] = 'El grupo tiene demasiados miembros';
+$string['maxmembers_notification'] = '¡Tu grupo tiene demasiados miembros! El máximo es {$a}.';
+$string['member'] = 'Miembro';
+$string['membercount'] = 'Contador';
+$string['membershidden'] = 'Lista de miembros no disponible';
+$string['memberslist'] = 'Miembros';
+$string['minmembers'] = 'Número mínimo de miembros por grupo';
+$string['minmembers_error_bigger_maxmembers'] = '¡Error: el tamaño mínimo debe ser menor que el máximo de participantes por grupo!';
+$string['minmembers_error_low'] = '¡Error: no se aceptan números negativos para el tamaño de grupo mínimo!';
+$string['minmembers_help'] = 'Número mínimo de miembros por grupo. Añade notificaciones para los miembros de los grupos que se encuentran por debajo de este límite. El valor predeterminado es 0 (desactivado).';
+$string['minmembers_icon'] = 'El grupo tiene menos miembros de los requeridos';
+$string['minmembers_notification'] = 'Su grupo tiene menos miembros del requerido! El mínimo es {$a}.';
+$string['modulename'] = 'Auto-selección de grupo';
+$string['modulename_help'] = '<p>Permite crear y seleccionar grupos a los propios estudiantes. Funcionalidades: </p><ul><li>Los estudiantes pueden crear grupos, con una descripción y protegerlos con una contraseña, si se quiere</li><li>Los estudiantes pueden elegir y unirse a grupos</li><li>Los supervisores se pueden asignar a grupos</li><li>El profesor puede exportar la lista de grupos del curso en un fichero csv</li><li>Plena compatibilidad con los grupos de Moodle: los grupos se pueden crear por cualquier otro método si fuese necesario, soporta entrega de tareas por grupo, etc.</li></ul>';
+$string['modulenameplural'] = 'Auto-selección de grupos';
+$string['nogroups'] = 'No hay grupos disponibles para seleccionar, lo lamentamos.';
+$string['notavailableanymore'] = 'La selección de grupos no está disponible, lo lamentos (desde el {$a}).';
+$string['notavailableyet'] = 'La selección de grupos estará disponible el {$a}.';
+$string['notifyexpiredselection'] = 'Muestra mensaje si se ha alcanzado la fecha "Permitir apuntarse hasta"';
+$string['notifyexpiredselection_help'] = 'Si se define, se mostrará un mensaje si se ha alcanzado la fecha "Permitir apuntarse hasta"';
+$string['ok'] = 'OK';
+$string['password'] = 'Requiere contraseña';
+$string['pluginadministration'] = 'Administración del módulo';
+$string['pluginname'] = 'Auto-selección de grupo';
+$string['saving'] = 'Guardando...';
+$string['select'] = 'Apuntarse al grupo {$a}';
+$string['selectconfirm'] = '¿Realmente quiere apuntarse al grupo <em>{$a}</em>?';
+$string['showassignedteacher'] = 'Mostrar profesores asignados';
+$string['showassignedteacher_help'] = 'Si se establece, los profesores asignados se mostrarán en la lista de miembros del grupo. Útil si los estudiantes necesitan conocer a sus profesores.';
+$string['studentcancreate'] = 'Los estudiantes pueden crear grupos';
+$string['studentcancreate_help'] = 'Si se establece, los estudiantes sin grupo (en el agrupamiento seleccionado) pueden crear grupos';
+$string['studentcansetdesc'] = 'Los estudiantes pueden establecer y editar la descripción del grupo';
+$string['studentcansetdesc_help'] = 'Si se establece, los estudiantes pueden fijar y editar la descripción del grupo al crearlo, y sus miembros podrán editarla';
+$string['studentcansetenrolmentkey'] = 'Los estudiantes podrán poner una clave para unirse a los grupos';
+$string['studentcansetenrolmentkey_help'] = 'Si se establece, los estudiantes podrán poner una clave de inscripción para apuntarse al grupo';
+$string['studentcansetgroupname'] = 'Los estudiantes podrán poner nombre a los grupos que creen';
+$string['studentcansetgroupname_help'] = 'Si se establece, los estudiantes podrán poner nombre a los grupos';
+$string['supervisionrole'] = 'Rol de supervisor';
+$string['supervisionrole_help'] = 'Define el rol de supervisor (por defecto profesores sin permisos de edición)';
+$string['targetgrouping'] = 'Selecionar grupo desde el agrupamiento';
+$string['timeavailable'] = 'Permitir apuntarse desde';
+$string['timeavailable_error_past_timedue'] = '¡Error: no se puede empezar después de la fecha límite!';
+$string['timedue'] = 'Permitir apuntarse hasta';
+$string['timedue_error_pre_timeavailable'] = '¡Error: no se puede acabar antes de la fecha de inicio!';
+$string['unselect'] = 'Abandonar el grupo {$a}';
+$string['unselectconfirm'] = '¿Realmente quiere abandonar el grupo <em>{$a}</em>?';

--- a/view.php
+++ b/view.php
@@ -37,7 +37,7 @@ $unselect = optional_param( 'unselect', 0, PARAM_INT );
 $confirm = optional_param( 'confirm', 0, PARAM_BOOL );
 $create = optional_param( 'create', 0, PARAM_BOOL );
 $password = optional_param( 'group_password', 0, PARAM_BOOL );
-$export = optional_param( 'export', 0, PARAM_BOOL );
+$exportformat = optional_param( 'exportformat', 0, PARAM_TEXT );
 $assign = optional_param( 'assign', 0, PARAM_BOOL );
 $unassign = optional_param( 'unassign', 0, PARAM_BOOL );
 $groupid = optional_param( 'groupid', 0, PARAM_INT );
@@ -77,9 +77,6 @@ $counts = groupselect_group_member_counts( $cm, $groupselect->targetgrouping );
 $groups = groups_get_all_groups( $course->id, 0, $groupselect->targetgrouping );
 $passwordgroups = groupselect_get_password_protected_groups( $groupselect );
 $hidefullgroups = $groupselect->hidefullgroups;
-$exporturl = '';
-
-groupselect_view($groupselect, $course, $cm, $context);
 
 // Course specific supervision roles.
 if (property_exists($groupselect, "supervisionrole") && $groupselect->supervisionrole > 0) {
@@ -308,8 +305,10 @@ if ($select and $canselect and isset( $groups[$select] ) and $isopen) {
 }
 
 // Group user data export.
-if ($export and $canexport) {
+if (($exportformat==='classicexportcsv' || $exportformat==='classicexportexcel' || $exportformat==='classicexportods') and $canexport) {
     // Fetch groups & assigned teachers.
+    
+    $fileformat = str_replace('classicexport','',$exportformat);
     $params = ['cmid' => $id, 'courseid' => $course->id, 'instanceid' => $groupselect->id];
     $groupingsql = '';
     if ($groupselect->targetgrouping) {
@@ -335,11 +334,9 @@ if ($export and $canexport) {
             JOIN {user} u ON u.id = m.userid
             WHERE  g.courseid = :courseid
             ORDER BY groupid ASC";
-
     $students = $DB->get_records_sql( $sql, $params );
 
     // Fetch max number of students in a group (may differ from setting, because teacher may add members w/o limits).
-
     $sql = "SELECT MAX(t.memberscount) AS max
             FROM (
                 SELECT g.id, COUNT(m.userid) AS memberscount
@@ -368,63 +365,51 @@ if ($export and $canexport) {
         }
     }
 
-    // Format data to csv.
-    $quote = '"';
-    $charstoescape = array(
-                        $quote => $quote.$quote
-                        );
+    // Format data to csv.    
     $assignedteacher = 'Assigned teacher ';
     $groupmember = 'Member ';
     $header = array(
-    // get_string ( 'groupid', 'mod_groupselect' ),
-    // get_string ( 'groupname', 'group' ),
-    // get_string ( 'groupdescription', 'group' ),
-    // get_string ( 'assignedteacher', 'mod_groupselect' ) . ' ' . get_string ( 'username' ),
-    // get_string ( 'assignedteacher', 'mod_groupselect' ) . ' ' . get_string ( 'firstname' ),
-    // get_string ( 'assignedteacher', 'mod_groupselect' ) . ' ' . get_string ( 'lastname' ),
-    // get_string ( 'assignedteacher', 'mod_groupselect' ) . ' ' . get_string ( 'email' )
-
         'Group ID',
         'Group Name',
         'Group Size',
         'Group Description',
-    $assignedteacher . 'Username',
-    $assignedteacher . 'Firstname',
-    $assignedteacher . 'Lastname',
-    $assignedteacher . 'Email',
-            );
+        $assignedteacher . 'Username',
+        $assignedteacher . 'Firstname',
+        $assignedteacher . 'Lastname',
+        $assignedteacher . 'Email',
+        );
 
     for ($i = 0; $i < $maxgroupsize; $i++) {
-        // $header[] = get_string('member', 'mod_groupselect').' '.strval($i+1).' '. get_string ( 'username' );
-        // $header[] = get_string('member', 'mod_groupselect').' '.strval($i+1).' '. get_string ( 'idnumber' );
-        // $header[] = get_string('member', 'mod_groupselect').' '.strval($i+1).' '. get_string ( 'firstname' );
-        // $header[] = get_string('member', 'mod_groupselect').' '.strval($i+1).' '. get_string ( 'lastname' );
-        // $header[] = get_string('member', 'mod_groupselect').' '.strval($i+1).' '. get_string ( 'email' );
-
         $header[] = $groupmember.strval($i + 1).' '.'Username';
         $header[] = $groupmember.strval($i + 1).' '.'ID Number';
         $header[] = $groupmember.strval($i + 1).' '.'Firstname';
         $header[] = $groupmember.strval($i + 1).' '.'Lastname';
         $header[] = $groupmember.strval($i + 1).' '.'Email';
     }
-    $content = implode( (','), $header ) . "\n";
+    
 
-    // TODO: add better export options
-    // Quick workaround for Excel
-    $content = 'sep=,' . "\n" . $content;
+    require_once ("{$CFG->libdir}/tablelib.php");
+    $exporttable = new flexible_table('groupselect_export_table');    
+    $exporttable->define_headers($header);
+    $exporttable->define_columns($header);            
+    $exporttable->setup();
+    $exporttable->is_downloading($fileformat,'export');    
+    $exporttable->start_output();    
 
-    foreach ($grouplist as $r) {
-        $row = array (
-                $quote.strtr($r->groupid, $charstoescape).$quote,
-                $quote.strtr($r->name, $charstoescape).$quote,
-                $quote.strtr($r->description, $charstoescape).$quote,
-                $quote.strtr($r->username, $charstoescape).$quote,
-                $quote.strtr($r->firstname, $charstoescape).$quote,
-                $quote.strtr($r->lastname, $charstoescape).$quote,
-                $quote.strtr($r->email, $charstoescape).$quote
+    foreach ($grouplist as $r) {        
+        $array_data = array (
+            $header[0] => $r->groupid, 
+            $header[1] => $r->name, 
+            $header[2] => $r->size, 
+            $header[3] => $r->description, 
+            $header[4] => $r->username, 
+            $header[5] => $r->firstname, 
+            $header[6] => $r->lastname, 
+            $header[7] => $r->email
         );
-        $groupsize = 0;
-        for ($i = 1; $i < $maxgroupsize + 1; $i++) {
+        $groupsize = 0;                
+        for ($i = 1, $j = 8; $i < $maxgroupsize + 1; $i++) {            
+            $row = array();
             if (isset($r->$i)) {
                 // First element contains group-member relation id which is not needed, so skip it
                 $first = true;
@@ -433,50 +418,86 @@ if ($export and $canexport) {
                         $first = false;
                         continue;
                     }
-                    $row[] = $quote.strtr($memberfield, $charstoescape).$quote;
+                    $row[$header[$j]] = $memberfield;
+                    $j++;
                 }
                 array_pop($row);
                 $groupsize++;
             }
+            $array_data = array_merge($array_data, $row);
         }
-        array_splice($row, 2, 0, $quote.strval($groupsize).$quote);
-        $content = $content . implode( (','), $row ) . "\n";
+        $exporttable->add_data_keyed($array_data,false);
     }
+    $exporttable->finish_output();
+    exit;
 
-    // File info
-    $separator = '_';
-    $filename = get_string( 'modulename', 'mod_groupselect' ) . $separator .
-            clean_param(format_string($course->shortname), PARAM_FILE) . $separator .
-                date( 'Y-m-d' ) . '.csv';
-    $filename = str_replace( ' ', '', $filename );
-    $fs = get_file_storage();
-    $fileinfo = array (
-            'contextid' => $context->id, // ID of context
-            'component' => 'mod_groupselect', // usually = table name
-            'filearea' => 'export', // usually = table name
-            'itemid' => $groupselect->id, // usually = ID of row in table
-            'filepath' => '/', // any path beginning and ending in /
-            'filename' => $filename
-    ); // any filename
+}
 
-    // See if same file exists
-    $file = $fs->get_file( $fileinfo['contextid'], $fileinfo['component'], $fileinfo['filearea'], $fileinfo['itemid'], $fileinfo['filepath'], $fileinfo['filename'] );
+if (($exportformat==='newexportcsv' || $exportformat==='newexportexcel' || $exportformat==='newexportods') and $canexport) {    
 
-    // Delete already existing file
-    if ($file) {
-        $file->delete();
+    $fileformat = str_replace('newexport','',$exportformat);
+    // Fetch students & groups
+    // Note: "get_records_sql" returns an associative array with with one objet for every distinct value of first field in select clause.
+    // memberid is used as 1st field to override this behavior and keep all rows (users belonging to more than one groups)
+    $sql = "SELECT  grp.memberid, u.username, u.id AS userid, u.firstname, u.lastname, u.email, grp.groupid, grp.groupname, grp.timeadded
+        FROM    {enrol} e, {user_enrolments} ue, {user} u
+        LEFT JOIN
+            (SELECT m.id as memberid, m.userid, g.id as groupid, g.name as groupname, m.timeadded as timeadded
+            FROM {groups} g, {groups_members} m
+            WHERE (
+            g.courseid = ?
+            AND g.id = m.groupid
+            )) grp
+        ON (grp.userid = u.id)
+        WHERE  e.courseid = ?
+        AND    e.id = ue.enrolid
+        AND    u.id = ue.userid";
+
+    $students_rs = $DB->get_recordset_sql ( $sql, array (
+        $course->id , $course->id
+    ) );
+
+    // Export all users. Group columns will be empty if the user is not member of groups in target grouping
+    $grouping_groups = groups_get_all_groups ($course->id, 0, $groupselect->targetgrouping); // Get groups of targetgrouping
+    $student_array = array();
+    foreach ($students_rs as $student){
+        $student_groupid = '';
+        $student_groupname = '';
+        $student_timeadded = '';
+        foreach ($grouping_groups as $group){
+            if ($student->groupid == $group->id){
+                $student_groupid = $group->id;
+                $student_groupname = $group->name;
+                $student_timeadded = date ('Y-m-d H:i:s', $student->timeadded);
+            }
+        }
+        $student->groupid = $student_groupid;
+        $student->groupname = $student_groupname;
+        $student->timeadded = $student_timeadded;
+        if (!isset($student_array[$student->userid]) || $student_groupid != '')
+            $student_array[$student->userid] = $student;
     }
+    $students_rs->close();
 
-    $file = $fs->create_file_from_string( $fileinfo, $content );
-    // Store file url to show later
-    $exporturl = moodle_url::make_pluginfile_url( $file->get_contextid(), $file->get_component(), $file->get_filearea(),
-                                                  $file->get_itemid(), $file->get_filepath(), $file->get_filename());
+    // Format data to csv
+    $header = array(
+        'lastname',
+        'firstname',
+        'email',
+        'groupname',
+        'timeadded'
+    );
 
-    // event logging
-    $event = \mod_groupselect\event\export_link_created::create(array(
-            'context' => $context,
-    ));
-    $event->trigger();
+    require_once ("{$CFG->libdir}/tablelib.php");
+    $exporttable = new flexible_table('groupselect_export_table');
+    $exporttable->define_headers($header);
+    $exporttable->define_columns($header);            
+    $exporttable->setup();
+    $exporttable->is_downloading($fileformat,'export');    
+    $exporttable->start_output();
+    $exporttable->format_and_add_array_of_rows($student_array,false);
+    $exporttable->finish_output();
+    exit;
 }
 
 // User wants to assign supervisors via supervisionrole
@@ -587,16 +608,22 @@ if ($cancreate and $isopen and ! $create) {
 
 // Export button.
 if ($canexport) {
-    if ($exporturl === '') {
-        echo $OUTPUT->single_button( new moodle_url( '/mod/groupselect/view.php', array (
-                    'id' => $cm->id,
-                    'export' => true
-            ) ), get_string( 'export', 'mod_groupselect' ) );
-    } else {
-        echo '<div class="export_url" >';
-        echo $OUTPUT->action_link( $exporturl, get_string( 'export_download', 'mod_groupselect' ) );
-        echo '</div> <br>';
-    }
+    /* Export formats dropdown*/
+    $exportoptions = array (        
+        'newexportcsv' => get_string('export_newcsv','mod_groupselect'),
+        'newexportexcel' => get_string('export_newexcel','mod_groupselect'),
+        'newexportods' => get_string('export_newods','mod_groupselect'),
+        'classicexportcsv' => get_string('export_classiccsv','mod_groupselect'),
+        'classicexportexcel' => get_string('export_classicexcel','mod_groupselect'),
+        'classicexportods' => get_string('export_classicods','mod_groupselect')
+    );
+
+    echo "<br /><form action=\"$CFG->wwwroot/mod/groupselect/view.php\" method=\"get\">\n";
+    echo "<input type=\"hidden\" name=\"id\" value=\"".$cm->id."\" />\n";
+    echo html_writer::label(get_string('export_formatchoose','mod_groupselect'), null, true);
+    echo html_writer::select($exportoptions, 'exportformat', '', false);
+    echo '  <input type="submit" value="'.get_string('download').'" />';
+    echo "</form>"; 
 }
 
 // Assign or unassign button.


### PR DESCRIPTION
- Choose export format dropdown.
- Updated code to use tablelib.
- Old export format is still available (classicexportcsv, classicexportexcel, classicexportods). One row per group.
- New export formats added: list of users with group membership (newexportcsv, newexportexcel, newexportods). One row per user. Group column empty for not members of target grouping (available groups).
- Column indicating when an user becomes member of the group in new export format.
- TRICK. Changing target-grouping to "All groups" and exporting with the new format, returns a list with all users and their groups.