### PR TITLE
Optionally override activity settings on restore.

### DIFF
--- a/backup/moodle2/restore_groupselect_stepslib.php
+++ b/backup/moodle2/restore_groupselect_stepslib.php
@@ -64,6 +64,17 @@ class restore_groupselect_activity_structure_step extends restore_activity_struc
             $data->targetgrouping = $this->get_mappingid('grouping', $data->targetgrouping);
         }
 
+        $config = get_config('groupselect');
+        foreach ($config as $key => $value) {
+            if (empty($data->$key) || $config->$key != $data->$key) {
+                $override = !empty($config->{$key . '_override'}) ? $config->{$key . '_override'} : '';
+                if (!empty($override)) {
+                    mtrace("activity setting skipped by {$key}_override setting in {$data->name}");
+                    $data->$key = $config->$key;
+                }
+            }
+        }
+
         // Insert the groupselect record.
         $newitemid = $DB->insert_record('groupselect', $data);
 

--- a/lang/en/groupselect.php
+++ b/lang/en/groupselect.php
@@ -125,3 +125,25 @@ $string['unassigngroup'] = 'Unassign supervisors from groups';
 $string['unassigngroup_confirm'] = 'This will unassign supervisors from groups. Are you sure?';
 $string['unselect'] = 'Leave group {$a}';
 $string['unselectconfirm'] = 'Do you really want to leave the group <em>{$a}</em>?';
+
+// Optionally override activity settings on restore.
+$string['minmembers_override'] = 'Override min members per group on restore';
+$string['maxmembers_override'] = 'Override max members per group on restore';
+$string['maxgroupmembership_override'] = 'Override maximum number of groups to participate in on restore';
+
+$string['studentcanjoin_override'] = 'Override participants can join groups on restore';
+$string['studentcanleave_override'] = 'Override participants can leave groups on restore';
+$string['studentcancreate_override'] = 'Override articipants can create groups on restore';
+$string['studentcansetgroupname_override'] = 'Override participants can set the name of new groups on restore';
+$string['studentcansetdesc_override'] = 'Override participants can set and edit group description on restore';
+$string['studentcansetenrolmentkey_override'] = 'Override participants can set passwords for joining groups on restore';
+
+$string['assigngroup_override'] = 'Override assign supervisors to groups on restore';
+$string['supervisionrole_override'] = 'Override supervisor role on restore';
+$string['showassignedteacher_override'] = 'Override show assigned supervisors on restore';
+$string['hidefullgroups_override'] = 'Override hide full groups from the main view on restore';
+$string['notifyexpiredselection_override'] = 'Override show message, if the open until date is reached on restore';
+$string['deleteemptygroups_override'] = 'Override delete group when last participant leaves on restore';
+
+$string['override_help'] = 'If checked, overrides the backed up value with the activity setting to perserve site defaults. Use case for restoring older version of the module which is missing the new settings.';
+

--- a/settings.php
+++ b/settings.php
@@ -41,14 +41,23 @@ if ($ADMIN->fulltree) {
     $settings->add(new admin_setting_configtext('groupselect/minmembers',
         get_string('minmembers', 'mod_groupselect'),
         get_string('minmembers_help', 'mod_groupselect'), 0, PARAM_INT));
+    $settings->add(new admin_setting_configcheckbox('groupselect/minmembers_override',
+        get_string('minmembers_override', 'mod_groupselect'),
+        get_string('override_help', 'mod_groupselect'), 0));
 
     $settings->add(new admin_setting_configtext('groupselect/maxmembers',
         get_string('maxmembers', 'mod_groupselect'),
         get_string('maxmembers_help', 'mod_groupselect'), 0, PARAM_INT));
+    $settings->add(new admin_setting_configcheckbox('groupselect/maxmembers_override',
+        get_string('maxmembers_override', 'mod_groupselect'),
+        get_string('override_help', 'mod_groupselect'), 0));
 
     $settings->add(new admin_setting_configtext('groupselect/maxgroupmembership',
         get_string('maxgroupmembership', 'mod_groupselect'),
         get_string('maxgroupmembership_help', 'mod_groupselect'), 1, PARAM_INT));
+    $settings->add(new admin_setting_configcheckbox('groupselect/maxgroupmembership_override',
+        get_string('maxgroupmembership_override', 'mod_groupselect'),
+        get_string('override_help', 'mod_groupselect'), 0));
     // -------------------------------------------------------
     // Enable Permissions.
     // -------------------------------------------------------
@@ -56,26 +65,44 @@ if ($ADMIN->fulltree) {
     $settings->add(new admin_setting_configcheckbox('groupselect/studentcanjoin',
         get_string('studentcanjoin', 'mod_groupselect'),
         get_string('studentcanjoin_help', 'mod_groupselect'), 1));
+    $settings->add(new admin_setting_configcheckbox('groupselect/studentcanjoin_override',
+        get_string('studentcanjoin_override', 'mod_groupselect'),
+        get_string('override_help', 'mod_groupselect'), 0));
 
     $settings->add(new admin_setting_configcheckbox('groupselect/studentcanleave',
         get_string('studentcanleave', 'mod_groupselect'),
         get_string('studentcanleave_help', 'mod_groupselect'), 1));
+    $settings->add(new admin_setting_configcheckbox('groupselect/studentcanleave_override',
+        get_string('studentcanleave_override', 'mod_groupselect'),
+        get_string('override_help', 'mod_groupselect'), 0));
 
     $settings->add(new admin_setting_configcheckbox('groupselect/studentcancreate',
         get_string('studentcancreate', 'mod_groupselect'),
         get_string('studentcancreate_help', 'mod_groupselect'), 1));
+    $settings->add(new admin_setting_configcheckbox('groupselect/studentcancreate_override',
+        get_string('studentcancreate_override', 'mod_groupselect'),
+        get_string('override_help', 'mod_groupselect'), 0));
 
     $settings->add(new admin_setting_configcheckbox('groupselect/studentcansetgroupname',
         get_string('studentcansetgroupname', 'mod_groupselect'),
         get_string('studentcansetgroupname_help', 'mod_groupselect'), 1));
+    $settings->add(new admin_setting_configcheckbox('groupselect/studentcansetgroupname_override',
+        get_string('studentcansetgroupname_override', 'mod_groupselect'),
+        get_string('override_help', 'mod_groupselect'), 0));
 
     $settings->add(new admin_setting_configcheckbox('groupselect/studentcansetdesc',
         get_string('studentcansetdesc', 'mod_groupselect'),
         get_string('studentcansetdesc_help', 'mod_groupselect'), 1));
+    $settings->add(new admin_setting_configcheckbox('groupselect/studentcansetdesc_override',
+        get_string('studentcansetdesc_override', 'mod_groupselect'),
+        get_string('override_help', 'mod_groupselect'), 0));
 
     $settings->add(new admin_setting_configcheckbox('groupselect/studentcansetenrolmentkey',
         get_string('studentcansetenrolmentkey', 'mod_groupselect'),
         get_string('studentcansetenrolmentkey_help', 'mod_groupselect'), 0));
+    $settings->add(new admin_setting_configcheckbox('groupselect/studentcansetenrolmentkey_override',
+        get_string('studentcansetenrolmentkey_override', 'mod_groupselect'),
+        get_string('override_help', 'mod_groupselect'), 0));
     // -------------------------------------------------------
     // Miscellaneous.
     // -------------------------------------------------------
@@ -83,24 +110,42 @@ if ($ADMIN->fulltree) {
     $settings->add(new admin_setting_configcheckbox('groupselect/assignteachers',
         get_string('assigngroup', 'mod_groupselect'),
         get_string('assigngroup_help', 'mod_groupselect'), 0));
+    $settings->add(new admin_setting_configcheckbox('groupselect/assigngroup_override',
+        get_string('assigngroup_override', 'mod_groupselect'),
+        get_string('override_help', 'mod_groupselect'), 0));
 
     $settings->add(new admin_setting_configselect('groupselect/supervisionrole',
         get_string('supervisionrole', 'mod_groupselect'),
         get_string('supervisionrole_help', 'mod_groupselect'), $setid, $configroles));
+    $settings->add(new admin_setting_configcheckbox('groupselect/supervisionrole_override',
+        get_string('supervisionrole_override', 'mod_groupselect'),
+        get_string('override_help', 'mod_groupselect'), 0));
 
     $settings->add(new admin_setting_configcheckbox('groupselect/showassignedteacher',
         get_string('showassignedteacher', 'mod_groupselect'),
         get_string('showassignedteacher_help', 'mod_groupselect'), 0));
+    $settings->add(new admin_setting_configcheckbox('groupselect/showassignedteacher_override',
+        get_string('showassignedteacher_override', 'mod_groupselect'),
+        get_string('override_help', 'mod_groupselect'), 0));
 
     $settings->add(new admin_setting_configcheckbox('groupselect/hidefullgroups',
         get_string('hidefullgroups', 'mod_groupselect'),
         get_string('hidefullgroups_help', 'mod_groupselect'), 0));
+    $settings->add(new admin_setting_configcheckbox('groupselect/hidefullgroups_override',
+        get_string('hidefullgroups_override', 'mod_groupselect'),
+        get_string('override_help', 'mod_groupselect'), 0));
 
     $settings->add(new admin_setting_configcheckbox('groupselect/notifyexpiredselection',
         get_string('notifyexpiredselection', 'mod_groupselect'),
         get_string('notifyexpiredselection_help', 'mod_groupselect'), 1));
+    $settings->add(new admin_setting_configcheckbox('groupselect/notifyexpiredselection_override',
+        get_string('notifyexpiredselection_override', 'mod_groupselect'),
+        get_string('override_help', 'mod_groupselect'), 0));
 
     $settings->add(new admin_setting_configcheckbox('groupselect/deleteemptygroups',
         get_string('deleteemptygroups', 'mod_groupselect'),
         get_string('deleteemptygroups_help', 'mod_groupselect'), 1));
+    $settings->add(new admin_setting_configcheckbox('groupselect/deleteemptygroups_override',
+        get_string('deleteemptygroups_override', 'mod_groupselect'),
+        get_string('override_help', 'mod_groupselect'), 0));
 }


### PR DESCRIPTION
This fix implements a feature to override backup settings on restore to ensure site defaults are maintenance instead of activity defaults are used when restore an old backups of the module which would be missing some settings.

Example use case, maintain these settings set to NO in the activity defaults:

 * Participants can create groups
 * Participants can set the name of new groups
 * Participants can set and edit group description

Testing Instructions:
Using a prior version of the activity (before v2018051900), create an activity and back it up.
Upgrade the activity, change the settings noted above to NO in the activity defaults.
Restore the activity and see the settings noted above restored as YES.
Check the override options for the site activity settings noted above and restore again to confirm they are restored as NO.