### PR TITLE
Optionally hide suspended students.

### DIFF
--- a/lang/en/groupselect.php
+++ b/lang/en/groupselect.php
@@ -125,3 +125,7 @@ $string['unassigngroup'] = 'Unassign supervisors from groups';
 $string['unassigngroup_confirm'] = 'This will unassign supervisors from groups. Are you sure?';
 $string['unselect'] = 'Leave group {$a}';
 $string['unselectconfirm'] = 'Do you really want to leave the group <em>{$a}</em>?';
+
+// Optionally hide suspended students.
+$string['hidesuspendedstudents'] = 'Hide suspended students';
+$string['hidesuspendedstudents_help'] = 'If checked, suspended students will be removed from user count and group lists';

--- a/tests/behat/hidesuspendedstudents.feature
+++ b/tests/behat/hidesuspendedstudents.feature
@@ -1,0 +1,46 @@
+@mod @mod_groupselect
+Feature: Setting to enable hiding of suspended students.
+
+  Background:
+    Given the following "courses" exist:
+      | fullname | shortname | category | groupmode |
+      | Course 1 | C1 | 0 | 1 |
+    And the following "users" exist:
+      | username | firstname | lastname | email |
+      | teacher1 | Teacher | 1 | teacher1@example.com |
+      | student1 | Student | 1 | student1@example.com |
+      | student2 | Student | 2 | student2@example.com |
+    And the following "course enrolments" exist:
+      | user | course | role | status |
+      | teacher1 | C1 | editingteacher | 0 |
+      | student1 | C1 | student | 0 |
+      | student2 | C1 | student | 1 |
+    And the following "groups" exist:
+      | name | course | idnumber |
+      | Group 1 | C1 | G1 |
+    And the following "group members" exist:
+      | user | group |
+      | student1 | G1 |
+      | student2 | G1 |
+    And I log in as "admin"
+    And I am on site homepage
+
+  Scenario: Setting is off, suspended students will be visible.
+    Given I follow "Course 1"
+    And I turn editing mode on
+    And I add a "Group self-selection" to section "1" and I fill the form with:
+      | Name        | Group self-selection       |
+    And I follow "Group self-selection"
+    Then I should see "Student 2"
+
+  Scenario: Turning the setting on, suspended students will be hidden.
+    Given I navigate to "Plugins > Activity modules > Group self-selection" in site administration
+    And I set the field "Hide suspended students" to "1"
+    And I press "Save changes"
+    And I am on site homepage
+    Then I follow "Course 1"
+    And I turn editing mode on
+    And I add a "Group self-selection" to section "1" and I fill the form with:
+      | Name        | Group self-selection       |
+    And I follow "Group self-selection"
+    Then I should not see "Student 2"

--- a/view.php
+++ b/view.php
@@ -73,7 +73,10 @@ $PAGE->set_activity_record( $groupselect );
 $mygroups = groups_get_all_groups( $course->id, $USER->id, $groupselect->targetgrouping, 'g.*' );
 $isopen = groupselect_is_open( $groupselect );
 $groupmode = groups_get_activity_groupmode( $cm, $course );
-$counts = groupselect_group_member_counts( $cm, $groupselect->targetgrouping );
+$config = get_config('groupselect');
+// Request group member counts without suspended students if enabled.
+$counts = groupselect_group_member_counts( $cm, $groupselect->targetgrouping, $config->hidesuspendedstudents);
+$susers = get_suspended_userids($context, true);
 $groups = groups_get_all_groups( $course->id, 0, $groupselect->targetgrouping );
 $passwordgroups = groupselect_get_password_protected_groups( $groupselect );
 $hidefullgroups = $groupselect->hidefullgroups;
@@ -710,6 +713,10 @@ if (empty ( $groups )) {
             if ($members = groups_get_members( $group->id )) {
                 $membernames = array ();
                 foreach ($members as $member) {
+                    // Hide suspended students from the member list if enabled.
+                    if (!empty($config->hidesuspendedstudents) && isset($susers[$member->id])) {
+                        continue;
+                    }
                     $pic = $OUTPUT->user_picture( $member, array (
                             'courseid' => $course->id
                     ) );


### PR DESCRIPTION
This item implements a feature to hide suspended students from user count and group lists so active students can enroll in the groups.

Testing Instructions:
 - Enroll Student B in a group A.
 - Suspend Student B in the course.
 - Create a Group selection with Max members to 1.
 - Verify Student A can't enroll in group A because it is full till the setting is enabled.
 - Verify that with the setting on, user count and group list will not include suspended Student B.
 - Verify Student A can enroll in group A now.