### PR TITLE
Take hidegroupmembers from activity setting.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 
-sudo: false
+os: linux
 
 cache:
   directories:
@@ -20,8 +20,8 @@ env:
  global:
 # - IGNORE_PATHS=jquery/jeditable,lib/sortable
   - IGNORE_NAMES=jquery.jeditable.js,sorttable.js
-  
- matrix:
+
+ jobs:
   - DB=pgsql MOODLE_BRANCH=MOODLE_35_STABLE
   - DB=pgsql MOODLE_BRANCH=MOODLE_36_STABLE
   - DB=pgsql MOODLE_BRANCH=MOODLE_37_STABLE

--- a/tests/behat/hidegroupmembers.feature
+++ b/tests/behat/hidegroupmembers.feature
@@ -1,0 +1,82 @@
+@mod @mod_groupselect
+Feature: Setting to enable hiding of group members students.
+  In order enrol to a group
+  As a student
+  I need to see other group members
+
+  Background:
+    Given the following "courses" exist:
+      | fullname | shortname | category |
+      | Course 1 | c1 | 0 |
+    And the following "users" exist:
+      | username | firstname | lastname | email |
+      | teacher1 | Teacher | 1 | teacher1@example.com |
+      | student1 | Student | 1 | student1@example.com |
+      | student2 | Student | 2 | student2@example.com |
+      | student3 | Student | 3 | student1@example.com |
+      | student4 | Student | 4 | student2@example.com |
+    And the following "course enrolments" exist:
+      | user     | course | role           |
+      | teacher1 | c1     | editingteacher |
+      | student1 | c1     | student        |
+      | student2 | c1     | student        |
+      | student3 | c1     | student        |
+      | student4 | c1     | student        |
+    And the following "groups" exist:
+      | name | course | idnumber |
+      | Group 1 | c1 | G1 |
+    And the following "group members" exist:
+      | user | group |
+      | student1 | G1 |
+
+  Scenario: Students see group members when choosing and hidegroupmembers is off.
+    Given I log in as "admin"
+    And I set the following system permissions of "Student" role:
+      | moodle/course:viewparticipants | Allow |
+    And I am on site homepage
+    And I follow "Course 1"
+    And I turn editing mode on
+    And I add a "Group self-selection" to section "1" and I fill the form with:
+      | Name        | Group self-selection       |
+      | Hide group members for students | 0      |
+    And I log out
+    And I log in as "student2"
+    And I am on "Course 1" course homepage
+    And I follow "Group self-selection"
+    And I should not see "Member list not available"
+    Then I should see "Student 1"
+
+  Scenario: Students do not see group members when choosing and hidegroupmembers is off but capability is off.
+    Given I log in as "admin"
+    And I set the following system permissions of "Student" role:
+      | moodle/course:viewparticipants | Prevent |
+    And I am on site homepage
+    And I follow "Course 1"
+    And I turn editing mode on
+    And I add a "Group self-selection" to section "1" and I fill the form with:
+      | Name        | Group self-selection       |
+      | Hide group members for students | 0      |
+    And I log out
+    And I log in as "student2"
+    And I am on "Course 1" course homepage
+    And I follow "Group self-selection"
+    And I should not see "Student 1"
+    Then I should see "Member list not available"
+
+  Scenario: Students do not see group members when choosing and hidegroupmembers is on.
+    Given I log in as "admin"
+    And I set the following system permissions of "Student" role:
+      | moodle/course:viewparticipants | Allow |
+    And I am on site homepage
+    And I follow "Course 1"
+    And I turn editing mode on
+    And I add a "Group self-selection" to section "1" and I fill the form with:
+      | Name        | Group self-selection       |
+      | Hide group members for students | 1      |
+    And I log out
+    And I log in as "student2"
+    And I am on "Course 1" course homepage
+    And I follow "Group self-selection"
+    And I should see "Student 2"
+    And I should not see "Student 1"
+    Then I should see "Member list not available"

--- a/view.php
+++ b/view.php
@@ -105,6 +105,7 @@ if (property_exists($groupselect, "supervisionrole") && $groupselect->supervisio
 
 // Permissions.
 $accessall = has_capability( 'moodle/site:accessallgroups', $context );
+$canmanagegroups = has_capability('moodle/course:managegroups', $context);
 $viewfullnames = has_capability( 'moodle/site:viewfullnames', $context );
 
 // multi group selection prerequisite.
@@ -124,8 +125,7 @@ $canassign = (has_capability( 'mod/groupselect:assign', $context ) and $groupsel
             and (count(groupselect_get_context_members_by_role( context_course::instance( $course->id )->id, $assignrole )) > 0));
 $canunassign = (has_capability( 'mod/groupselect:assign', $context ) and $alreadyassigned);
 $canedit = ($groupselect->studentcansetdesc and $isopen);
-$canmanagegroups = has_capability('moodle/course:managegroups', $context);
-$hidegroupmembers = !($canmanagegroups or $accessall);
+$hidegroupmembers = $groupselect->hidegroupmembers;
 $cansetgroupname = ($groupselect->studentcansetgroupname);
 
 $viewothers = null;


### PR DESCRIPTION
Hi Roger

Unfortunately you missed an occurence of
`$hidegroupmembers = $groupselect->hidegroupmembers;`
which lead to a bug, by which group members weren't able to see each other any more.

I created this patch for you and also added Behat tests to check the behaviour and display.
Additionally there are some slight changes to the .travis.yml file so it passes the new requirements checked by the validation tool [Travis CI Build Config Explorer](https://config.travis-ci.com/explore).

Best,
Luca