### PR TITLE
Adding activity dates information fixes #89.

### DIFF
--- a/.github/workflows/moodle-plugin-ci.yml
+++ b/.github/workflows/moodle-plugin-ci.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -13,6 +13,18 @@ jobs:
             database: 'pgsql'
           - php: '7.4'
             moodle-branch: 'master'
+            database: 'mariadb'
+          - php: '8.0'
+            moodle-branch: 'MOODLE_400_STABLE'
+            database: 'pgsql'
+          - php: '7.4'
+            moodle-branch: 'MOODLE_400_STABLE'
+            database: 'mariadb'
+          - php: '8.0'
+            moodle-branch: 'MOODLE_311_STABLE'
+            database: 'pgsql'
+          - php: '7.4'
+            moodle-branch: 'MOODLE_311_STABLE'
             database: 'mariadb'
 
     services:

--- a/classes/dates.php
+++ b/classes/dates.php
@@ -1,0 +1,77 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Version information
+ *
+ * @package    mod_groupselect
+ * @copyright  2022 Luca Bösch <luca.boesch@bfh.ch>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+declare(strict_types=1);
+
+namespace mod_groupselect;
+
+use core\activity_dates;
+
+/**
+ * Class for fetching the important dates in mod_groupselect for a given module instance and a user.
+ *
+ * @copyright 2021 Shamim Rezaie <shamim@moodle.com>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class dates extends activity_dates {
+
+    /**
+     * Returns a list of important dates in mod_groupselect
+     * (code copied from /mod/assign/classes/dates.php)
+     *
+     * @return array
+     */
+    protected function get_dates(): array {
+
+        list($course, $module) = get_course_and_cm_from_cmid($this->cm->id);
+
+        $groupselect = groupselect_get_groupselect($module->instance);
+
+        $timeopen = $groupselect->timeavailable ?? null;
+        $timeclose = $groupselect->timedue ?? null;
+
+        $now = time();
+        $dates = [];
+
+        if ($timeopen) {
+            $openlabelid = $timeopen > $now ? 'activitydate:willopen' : 'activitydate:hasopened';
+            $date = [
+                    'label'     => get_string($openlabelid, 'mod_groupselect'),
+                    'timestamp' => (int)$timeopen,
+            ];
+            $dates[] = $date;
+        }
+
+        if ($timeclose) {
+            $closelabelid = $timeopen > $now ? 'activitydate:hasclosed' : 'activitydate:willclose';
+            $date = [
+                    'label'     => get_string($closelabelid, 'mod_groupselect'),
+                    'timestamp' => (int)$timeclose,
+            ];
+            $dates[] = $date;
+        }
+
+        return $dates;
+    }
+}

--- a/lang/en/groupselect.php
+++ b/lang/en/groupselect.php
@@ -27,6 +27,10 @@
 defined('MOODLE_INTERNAL') || die;
 
 $string['action'] = 'Action';
+$string['activitydate:willopen'] = 'Opens:';
+$string['activitydate:hasopened'] = 'Opened:';
+$string['activitydate:willclose'] = 'Closes:';
+$string['activitydate:hasclosed'] = 'Closed:';
 $string['assignedteacher'] = 'Supervisor';
 $string['assigngroup'] = 'Assign supervisors to groups';
 $string['assigngroup_help'] = 'If set, enables a button which assigns supervisors to groups (if course has supervisors). Assigned supervisors are not group members, but they show up in export file and in the main view (if set). Useful if course uses assistants to handle groups. This permission can be set further in the role capabilities.';

--- a/lib.php
+++ b/lib.php
@@ -31,62 +31,38 @@
  * @return mixed True if module supports feature, false if not, null if doesn't know
  */
 function groupselect_supports($feature) {
-    if (defined('FEATURE_MOD_PURPOSE') && defined('MOD_PURPOSE_ASSESSMENT')) {
-        // Moodle ≥ 4.0.
-        switch($feature) {
-            case FEATURE_MOD_ARCHETYPE:
-                return MOD_ARCHETYPE_OTHER;
-            case FEATURE_GROUPS:
-                return true;  // Only separate mode makes sense - you hide members of other groups here.
-            case FEATURE_GROUPINGS:
-                return false; // Should be true. Separate setting in groupselect.
-            case FEATURE_GROUPMEMBERSONLY:
-                return false; // This could be very confusing.
-            case FEATURE_MOD_INTRO:
-                return true;
-            case FEATURE_COMPLETION_TRACKS_VIEWS:
-                return true;
-            case FEATURE_GRADE_HAS_GRADE:
-                return false;
-            case FEATURE_GRADE_OUTCOMES:
-                return false;
-            case FEATURE_BACKUP_MOODLE2:
-                return true;
-            case FEATURE_SHOW_DESCRIPTION:
-                return true;
-            case FEATURE_MOD_PURPOSE:
-                return MOD_PURPOSE_COLLABORATION;
+    if (!defined('FEATURE_MOD_PURPOSE')) {
+        define('FEATURE_MOD_PURPOSE', 'mod_purpose');
+    }
+    if (!defined('MOD_PURPOSE_COLLABORATION')) {
+        define('MOD_PURPOSE_COLLABORATION', 'collaboration');
+    }
 
-            default:
-                return null;
-        }
-    } else {
-        // Moodle ≤ 3.11.
-        switch($feature) {
-            case FEATURE_MOD_ARCHETYPE:
-                return MOD_ARCHETYPE_OTHER;
-            case FEATURE_GROUPS:
-                return true;  // Only separate mode makes sense - you hide members of other groups here.
-            case FEATURE_GROUPINGS:
-                return false; // Should be true. Separate setting in groupselect.
-            case FEATURE_GROUPMEMBERSONLY:
-                return false; // This could be very confusing.
-            case FEATURE_MOD_INTRO:
-                return true;
-            case FEATURE_COMPLETION_TRACKS_VIEWS:
-                return true;
-            case FEATURE_GRADE_HAS_GRADE:
-                return false;
-            case FEATURE_GRADE_OUTCOMES:
-                return false;
-            case FEATURE_BACKUP_MOODLE2:
-                return true;
-            case FEATURE_SHOW_DESCRIPTION:
-                return true;
-
-            default:
-                return null;
-        }
+    switch($feature) {
+        case FEATURE_MOD_ARCHETYPE:
+            return MOD_ARCHETYPE_OTHER;
+        case FEATURE_GROUPS:
+            return true;  // Only separate mode makes sense - you hide members of other groups here.
+        case FEATURE_GROUPINGS:
+            return false; // Should be true. Separate setting in groupselect.
+        case FEATURE_GROUPMEMBERSONLY:
+            return false; // This could be very confusing.
+        case FEATURE_MOD_INTRO:
+            return true;
+        case FEATURE_COMPLETION_TRACKS_VIEWS:
+            return true;
+        case FEATURE_GRADE_HAS_GRADE:
+            return false;
+        case FEATURE_GRADE_OUTCOMES:
+            return false;
+        case FEATURE_BACKUP_MOODLE2:
+            return true;
+        case FEATURE_SHOW_DESCRIPTION:
+            return true;
+        case FEATURE_MOD_PURPOSE:
+            return MOD_PURPOSE_COLLABORATION;
+        default:
+            return null;
     }
 }
 
@@ -96,6 +72,21 @@ function groupselect_supports($feature) {
  */
 function groupselect_get_extra_capabilities() {
     return array('moodle/site:accessallgroups', 'moodle/site:viewfullnames');
+}
+
+/**
+ * Gets a full groupselect record
+ *
+ * @param int $groupselectid
+ * @return object|bool The groupselect or false
+ */
+function groupselect_get_groupselect($groupselectid) {
+    global $DB;
+
+    if ($groupselect = $DB->get_record("groupselect", array("id" => $groupselectid))) {
+        return $groupselect;
+    }
+    return false;
 }
 
 /**

--- a/tests/behat/activitydates.feature
+++ b/tests/behat/activitydates.feature
@@ -1,0 +1,36 @@
+@mod @mod_groupselect
+Feature: See the group self-selection activity dates.
+  In order to enrol in a group in timely manner
+  As a student
+  I need to see the group self-selection dates
+
+  Background:
+    Given the following "courses" exist:
+      | fullname | shortname | category | showactivitydates |
+      | Course 1 | C1        | 0        | 1                 |
+    And the following "users" exist:
+      | username | firstname | lastname | email                |
+      | teacher1 | Teacher   | 1        | teacher1@example.com |
+      | student1 | Student   | 1        | student1@example.com |
+    And the following "course enrolments" exist:
+      | user     | course | role           |
+      | teacher1 | C1     | editingteacher |
+      | student1 | C1     | student        |
+
+  @javascript
+  Scenario: Students see activity dates of group self-selection.
+    Given I log in as "teacher1"
+    And I am on "Course 1" course homepage with editing mode on
+    And I add a "Group self-selection" to section "1" and I fill the form with:
+      | Name                     | Group self-selection |
+      | id                       | scheduler1           |
+      | id_timeavailable_enabled | 1                    |
+      | id_timeavailable_day     | 1                    |
+      | id_timeavailable_month   | 1                    |
+      | id_timeavailable_year    | 2024                 |
+      | id_timedue_enabled       | 1                    |
+      | id_timedue_month         | 12                   |
+      | id_timedue_day           | 31                   |
+      | id_timedue_year          | 2024                 |
+    And I am on the "Course 1" Course page logged in as student1
+    Then the activity date information in "Group self-selection" should exist

--- a/tests/behat/behat_mod_groupselect.php
+++ b/tests/behat/behat_mod_groupselect.php
@@ -1,0 +1,40 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Steps definitions related with the group self-selection activity.
+ *
+ * @package    mod_groupselect
+ * @category   test
+ * @copyright  2022 Luca Bösch <luca.boesch@bfh.ch>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+// NOTE: no MOODLE_INTERNAL test here, this file may be required by behat before including /config.php.
+require_once(__DIR__ . '/../../../../lib/behat/behat_base.php');
+
+use Behat\Behat\Context\Step\Given as Given, Behat\Behat\Context\Step\When as When, Behat\Gherkin\Node\TableNode as TableNode;
+/**
+ * Group self-selection steps definitions.
+ *
+ * @package mod_groupselect
+ * @category test
+ * @copyright  2022 Luca Bösch <luca.boesch@bfh.ch>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class behat_mod_groupselect extends behat_base {
+
+}

--- a/view.php
+++ b/view.php
@@ -536,6 +536,21 @@ if ($assign && $canassign) {
 
 echo $OUTPUT->header();
 
+if ($CFG->branch < 400) {
+    if (class_exists('\core\activity_dates')) {
+        // Show the activity dates.
+        $modinfo = get_fast_modinfo($course);
+        $cminfo = $modinfo->get_cm($cm->id);
+        $cmcompletion = \core_completion\cm_completion_details::get_instance($cminfo, $USER->id); // Fetch completion information.
+        $activitydates = \core\activity_dates::get_dates_for_module($cminfo, $USER->id);
+        echo $OUTPUT->activity_information($cminfo, $cmcompletion, $activitydates);
+    }
+    if (trim( strip_tags( $groupselect->intro ) )) {
+        echo $OUTPUT->box_start( 'mod_introbox', 'groupselectintro' );
+        echo format_module_intro( 'groupselect', $groupselect, $cm->id );
+        echo $OUTPUT->box_end();
+    }
+}
 
 // Too few members in my group-notification.
 if ($groupselect->minmembers > 0 && ! empty( $mygroups )) {


### PR DESCRIPTION
Hi Roger

I built in the activity dates.
Besides, you probably want to undo the handling of Moodle < 4.0 versions in https://github.com/rogerbaba/moodle-mod_groupselect/commit/6f5bc2d50bfdb3ebe2a2a0755a68b6678039247b because of what’s explained here https://github.com/ndunand/moodle-mod_choicegroup/issues/172.
It creates an incompability with 3.11 and earlier.
I fixed this with that pull request, too, using this trick here https://github.com/ndunand/moodle-mod_choicegroup/blob/master/lib.php#L54. As you see, the Github actions do pass with Moodle 3.11, 4.0 and master.

Best,
Luca