### PR TITLE
Version comment needs full stop.

### DIFF
--- a/select_form.php
+++ b/select_form.php
@@ -45,7 +45,6 @@ class select_form extends moodleform {
      * Definition of the form
      */
     public function definition() {
-        global $OUTPUT;
         $mform = $this->_form;
 
         list( $data, $this->groupselect, $grpname ) = $this->_customdata;
@@ -78,7 +77,6 @@ class select_form extends moodleform {
      * @return array
      */
     public function validation($data, $files) {
-        global $OUTPUT;
 
         $errors = parent::validation( $data, $files );
 

--- a/version.php
+++ b/version.php
@@ -27,7 +27,7 @@
 defined('MOODLE_INTERNAL') || die;
 
 $plugin->version   = 2022112400; // The current module version (Date: YYYYMMDDXX).
-$plugin->requires  = 2020061500; // Requires this Moodle version 3.9
+$plugin->requires  = 2020061500; // Requires this Moodle version 3.9.
 $plugin->cron      = 0;          // Period for cron to check this module (secs).
 $plugin->component = 'mod_groupselect'; // Full name of the plugin (used for diagnostics).
 $plugin->maturity  = MATURITY_STABLE;


### PR DESCRIPTION
This is so incredibly minor but it fixes this

```
Run moodle-plugin-ci codechecker
RUN  Moodle CodeSniffer standard on mod_groupselect
............................W. 30 / 30 (100%)



FILE: /home/runner/work/moodle-mod_groupselect/moodle-mod_groupselect/moodle/mod/groupselect/version.php
------------------------------------------------------------------------------------------------------------------------------------
FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
------------------------------------------------------------------------------------------------------------------------------------
 30 | WARNING | Inline comments must end in full-stops, exclamation marks, or question marks
    |         | (moodle.Commenting.InlineComment.InvalidEndChar)
------------------------------------------------------------------------------------------------------------------------------------

Time: 667ms; Memory: 22MB

```

and this

```

FILE: mod/groupselect/select_form.php
FOUND 0 ERRORS AND 2 VIOLATIONS
 ==== =========== ================================================= 
  48   VIOLATION   Avoid unused local variables such as '$OUTPUT'.  
  81   VIOLATION   Avoid unused local variables such as '$OUTPUT'.  
 ==== =========== ================================================= 

```
